### PR TITLE
Raro 949/doc issues

### DIFF
--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -73,14 +73,12 @@ You can check out the source code and compile the `.war` files. Follow the quick
 1. Java 8
 2. Tomcat
 3. MySQL
-4. Solr (optional)
 
 ### Java 8
 Your runtime environment must support Java 8 or later. To develop and compile the webapps, the Java 8 Development Kit (JDK8) is required.
 
 ### Tomcat
 Ambra has been tested with Tomcat 7 and should be compatible with the latest Tomcat.
-
 
 ### MySQL
 Ambra requires a running MySQL server. It has been tested with version 5.6.28 and should be compatible with the latest version of MySQL.

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -104,7 +104,7 @@ Add a journal to the database:
 INSERT INTO journal (`journalKey`, `title`, `eissn`) VALUES ("my_journal", "My Journal", "0000-0000");
 ```
 
-* `journalKey` - an identifier used in config files
+* `journalKey` - an identifier used in config files. A theme is set for a journal by setting `journalKey` in `journal.yaml`. See [Themes Quickstart](themes-customizing.html) for more on themes.
 * `title` - the journal title
 * `eissn` - the journal's [electronic ISSN (e-ISSN)](http://www.issn.org/). Articles identify the journal to which they are added by e-ISSN (see the [Ingestible Package Guide](https://plos.github.io/ambraproject/Ingestible-Package-Guide.html) for details). For the sample database we will use a dummy value: `0000-0000`.
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -25,12 +25,8 @@ These instructions are targeted at Linux and iOS systems. We have not tried to i
     2. [Setting up the databases](#setting-up-the-databases)
     3. [Directories](#directories)
     4. [Configuration files](#configuration-files)
-4. [Setting up a theme directory](#setting-up-a-theme-directory)
-    1. [Theme Overrides](#theme-overrides)
-    2. [Journal Configuration](#journal-configuration)
-    3. [Homepage Customization](#homepage-customization)
-5. [Running the Application](#running-the-application)
-    1. [Confirming that the application is running](#confirming-that-the-application-is-running)
+4. [Running the Application](#running-the-application)
+5. [Confirming that the application is running](#confirming-that-the-application-is-running)
 6. [Ingesting an article](#ingesting-an-article)
 
 # Walkthrough of the Ambra core components
@@ -104,7 +100,7 @@ Add a journal to the database:
 INSERT INTO journal (`journalKey`, `title`, `eissn`) VALUES ("my_journal", "My Journal", "0000-0000");
 ```
 
-* `journalKey` - an identifier used in config files. A theme is set for a journal by setting `journalKey` in `journal.yaml`. See [Themes Quickstart](themes-customizing.html) for more on themes.
+* `journalKey` - an identifier used in config files. A theme is set for a journal by setting `journalKey` in `journal.yaml`. For more on themes see the [Themes Quickstart](themes-customizing.html).
 * `title` - the journal title
 * `eissn` - the journal's [electronic ISSN (e-ISSN)](http://www.issn.org/). Articles identify the journal to which they are added by e-ISSN (see the [Ingestible Package Guide](https://plos.github.io/ambraproject/Ingestible-Package-Guide.html) for details). For the sample database we will use a dummy value: `0000-0000`.
 
@@ -173,6 +169,7 @@ cd $HOME
 pwd # This prints the path to your home directory. Edit the file /etc/ambra/wombat.yaml and replace $HOME with this path.  
 ```
 
+For more on themes see the [Themes Quickstart](themes-customizing.html) and [Working with PLOS's Themes ](themes-documenation.html).
 
 # Running the Application
 ## Running the application from source code with Maven

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -29,8 +29,8 @@ These instructions are targeted at Linux and iOS systems. We have not tried to i
     1. [Theme Overrides](#theme-overrides)
     2. [Journal Configuration](#journal-configuration)
     3. [Homepage Customization](#homepage-customization)
-5. [Deploying the artifacts to Tomcat](#deploying-the-artifacts-to-tomcat)
-    1. [Viewing the "hello world" page for each component](#viewing-the-hello-world-page-for-each-component)
+5. [Running the Application](#running-the-application)
+    1. [Confirming that the application is running](#confirming-that-the-application-is-running)
 6. [Ingesting an article](#ingesting-an-article)
 
 # Walkthrough of the Ambra core components
@@ -48,21 +48,21 @@ Rhino is the back-end service for ingesting and storing article content and meta
 The Content Repo is an append-only repository of article assets, including the manuscript XML and all images.
 
 # Obtaining the Applications
-## Download the latest releases
-
-You can run Ambra in Tomcat without compiling any code.  Download latest releases:
-- [Wombat](https://plos.github.io/ambraproject/Releases.html#wombat)
-- [Rhino](https://plos.github.io/ambraproject/Releases.html#rhino)
-- [Content Repo](https://plos.github.io/ambraproject/Releases.html#content-repo)
-
-## Alternative: Run the source code
-You can check out the source code and compile the `.war` files. Follow the quick start guide and run the applications with Maven instead of deploying the web app to Tomcat.  The source repositories are here:
+## Download the source code
+You can check out the source code and run the applications with Tomcat and Maven. The source repositories are here:
 
 * [Wombat](https://github.com/PLOS/wombat.git)
 * [Rhino](https://github.com/PLOS/rhino.git)
 * [Content Repo](https://github.com/PLOS/content-repo.git)
 
-## Alternative: Docker
+### Alternative: Download the latest releases
+
+You can deploy Ambra in Tomcat without compiling the source code.  Download latest releases:
+- [Wombat](https://plos.github.io/ambraproject/Releases.html#wombat)
+- [Rhino](https://plos.github.io/ambraproject/Releases.html#rhino)
+- [Content Repo](https://plos.github.io/ambraproject/Releases.html#content-repo)
+
+### Alternative: Docker
 [See our Docker setup guide](https://github.com/PLOS/Dockerfiles/wiki/Ambra-Quick-Start).  You can quickly bring up an auto-configured Ambra stack using Docker instead of having to follow this quickstart guide.
 
 # System setup
@@ -174,25 +174,25 @@ pwd # This prints the path to your home directory. Edit the file /etc/ambra/womb
 ```
 
 
-## Running the applications
-
-You should be familiar with how to deploy a webapp to Tomcat. Typically, `.war` files are simply copied into Tomcat's `webapps` directory and Tomcat will start the webapp automatically.
-
-### Alternative: Running the application from source code with Maven
+# Running the Application
+## Running the application from source code with Maven
 Use Maven to run the applications from source. For each respective app you must be in the checked-out repository directory.
 1. Compile the app: `mvn install`
 2. Run the app:
-   1. Wombat: `mvn tomcat6:run -Dmaven.tomcat.port=8080 -Dwombat.configDir=/etc/ambra`
-   2. Rhino: `mvn tomcat6:run -Dmaven.tomcat.port=8082 -Drhino.configDir=/etc/ambra`
-   3. Content Repo: `mvn tomcat6:run -Dmaven.tomcat.port=8081`
+- Wombat: `mvn tomcat6:run -Dmaven.tomcat.port=8080 -Dwombat.configDir=/etc/ambra`
+- Rhino: `mvn tomcat6:run -Dmaven.tomcat.port=8082 -Drhino.configDir=/etc/ambra`
+- Content Repo: `mvn tomcat6:run -Dmaven.tomcat.port=8081`
 
-## Viewing the "hello world" page for each component
+### Alternative: Deploying the latest release to Tomcat
+You should be familiar with how to deploy a webapp to Tomcat. Typically, `.war` files are simply copied into Tomcat's `webapps` directory and Tomcat will start the webapp automatically.
+
+## Confirming that the application is running
 
 Go to `http://localhost:<PORT>` to view the root page for each application.
 
-1. Wombat: You should see an introductory web page at `http://localhost:8080`
-2. Rhino: You should see a Swagger API interface at `http://localhost:8082`
-3. Content Repo: You should see a Swagger API interface at `http://localhost:8081`
+- Wombat: You should see an introductory web page at `http://localhost:8080`
+- Rhino: You should see a Swagger API interface at `http://localhost:8082`
+- Content Repo: You should see a Swagger API interface at `http://localhost:8081`
 
 ## Ingesting an article
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -112,6 +112,18 @@ mysql -uroot -e "DROP DATABASE IF EXISTS repo;"
 mysql -uroot -e "CREATE DATABASE repo;"
 ```
 
+Download the Content Repo schema ([`content-repo-schema.sql`](https://plos.github.io/ambraproject/example/content-repo-schema.sql)) and import it into the `repo` database. For example:
+
+```bash
+mysql -h 127.0.0.1 -P 3306 -uroot -p repo < content-repo-schema.sql
+```
+
+Add a bucket named "corpus" to the database.
+
+```sql
+INSERT INTO buckets (`bucketName`) VALUES ("corpus");
+```
+
 ### Directories
 
 You will need to create a configuration directory and a directory to hold files in CRepo's datastore.

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -85,6 +85,7 @@ Ambra has been tested with Tomcat 7 and should be compatible with the latest Tom
 Ambra requires a running MySQL server. It has been tested with version 5.6.28 and should be compatible with the latest version of MySQL.
 
 ## Setting Up the Databases
+
 #### Ambra database
 
 ```bash
@@ -127,39 +128,40 @@ Add a bucket named "corpus" to the database.
 INSERT INTO buckets (`bucketName`) VALUES ("corpus");
 ```
 
+## Setting Up Configuration
 ### Directories
 
-You will need to create a configuration directory and a directory to hold files in Content Repo's datastore.
+Create the following directories:
+- a directory to hold configuration files
+- a directory to hold files in the Content Repo's datastore
 
 On a toy system, a recommended setup is:
 
 ```bash
   mkdir $HOME/ambra
-  mkdir $HOME/ambra/crepo_datastore  # Content Repo datastore directory
   mkdir $HOME/ambra/config           # configuration directory
+  mkdir $HOME/ambra/crepo_datastore  # Content Repo datastore directory
 ```
 
 On a production system, `/etc/ambra` is recommended for the configuration directory.
 
 ### Configuration files
 
+#### Shared
+Rhino, Wombat, and Content Repo all run on Tomcat. For this quick start they will all run on the same Tomcat server and they will share the same `context.xml` ([example](https://plos.github.io/ambraproject/example/context.xml)).  Place this file in the configuration directory you created above.
+
 #### Rhino
-
-Rhino requires two configuration files placed in configuration directory.
-
-1. `rhino.yaml` ([example](https://plos.github.io/ambraproject/example/rhino.yaml))
-2. `context.xml` ([example](https://plos.github.io/ambraproject/example/context.xml))
-
-The files listed above have some required fields - see the example files included in this project. *Note that due to a known bug, the context.xml file must be in /etc/ambra/context.xml*.
-
-#### Wombat
-
-Wombat requires a configuration file named `wombat.yaml` ([example](https://plos.github.io/ambraproject/example/wombat.yaml)) placed in the configuration directory. It has some required fields.
-The `path` variable must have an actual path, don't use $HOME.
+Rhino requires it's own configuration file placed in the configuration directory:
+`rhino.yaml` ([example](https://plos.github.io/ambraproject/example/rhino.yaml)).
+It has some required fields.
 
 #### Content Repo
+The shared `context.xml` in your configuration directory must contain a path to the Content Repo data store.
 
-In addition to the Rhino configuration, the `context.xml` ([example](https://plos.github.io/ambraproject/example/context.xml)) in your configuration directory must also be configured to provide Content Repo with a directory to use as its data store.
+#### Wombat
+Wombat requires it's own configuration file placed in the configuration directory: `wombat.yaml` ([example](https://plos.github.io/ambraproject/example/wombat.yaml)).
+It has some required fields.
+The `path` variable must have an actual path, don't use $HOME.
 
 ## Setting up a theme directory
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -159,7 +159,7 @@ The shared `context.xml` in your configuration directory must contain a path to 
 Wombat requires it's own configuration file placed in the configuration directory: `wombat.yaml` ([example](https://plos.github.io/ambraproject/example/wombat.yaml)).
 It has some required fields.
 
-Wombat can be themed and will not start without having a theme installed.  Create the theme by downloading and extracting the following archive [`themes.tar.gz`](https://plos.github.io/ambraproject/example/themes.tar.gz).
+Wombat can be themed and requires a default theme to be present.  Create the theme by downloading and extracting the following archive [`themes.tar.gz`](https://plos.github.io/ambraproject/example/themes.tar.gz).
 
 ```bash
 cd $HOME/ambra/

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -69,13 +69,16 @@ Maven is required to compile components of the Ambra stack. Each component can b
 
 ### Overview
 1. Java 8
-2. MySQL
-3. Tomcat
+2. Tomcat
+3. MySQL
 4. Solr (optional)
 5. Maven (optional)
 
 ### Java 8
 Your runtime environment must support Java 8 or later. To develop and compile the webapps, the Java 8 Development Kit (JDK8) is required.
+
+### Tomcat
+Ambra has been tested with Tomcat 7.
 
 ## Setting Up the Databases
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -105,9 +105,9 @@ Add a journal to the database:
 INSERT INTO journal (`journalKey`, `title`, `eissn`) VALUES ("my_journal", "My Journal", "0000-0000");
 ```
 
-* `journalKey` - an identifier used in config files. It must match the key configured in `journal.yaml` ([see below](#themes-configuration)).
-* `title` - the reader-facing display form of the title.
-* `eissn` - the journal's [electronic ISSN (e-ISSN)](http://www.issn.org/). It must match the e-ISSN for articles ingested into the system (see the [Ingestible Package Guide](https://plos.github.io/ambraproject/Ingestible-Package-Guide.html) for details). On a toy system, use a dummy value such as `0000-0000`.
+* `journalKey` - an identifier used in config files
+* `title` - the journal title
+* `eissn` - the journal's [electronic ISSN (e-ISSN)](http://www.issn.org/). Articles identify the journal to which they are added by e-ISSN (see the [Ingestible Package Guide](https://plos.github.io/ambraproject/Ingestible-Package-Guide.html) for details). For the sample database we will use a dummy value: `0000-0000`.
 
 #### Content Repo database
 
@@ -134,8 +134,6 @@ INSERT INTO buckets (`bucketName`) VALUES ("corpus");
 Create the following directories:
 - a directory to hold configuration files
 - a directory to hold files in the Content Repo's datastore
-
-On a toy system, a recommended setup is:
 
 ```bash
   mkdir $HOME/ambra
@@ -172,7 +170,7 @@ tar -xvzf themes.tar.gz
 ```
 
 
-## Deploying the artifacts to Tomcat
+## Deploying the applications to Tomcat
 
 If you have downloaded or compiled `.war` files, you may deploy them to a Tomcat instance as normal. (Consult the Tomcat documentation for details.)
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -160,7 +160,6 @@ The shared `context.xml` in your configuration directory must contain a path to 
 #### Wombat
 Wombat requires it's own configuration file placed in the configuration directory: `wombat.yaml` ([example](https://plos.github.io/ambraproject/example/wombat.yaml)).
 It has some required fields.
-The `path` variable must have an actual path, don't use $HOME.
 
 Wombat can be themed and will not start without having a theme installed.  Create the theme by downloading and extracting the following archive [`themes.tar.gz`](https://plos.github.io/ambraproject/example/themes.tar.gz).
 
@@ -168,6 +167,12 @@ Wombat can be themed and will not start without having a theme installed.  Creat
 cd $HOME/ambra/
 wget https://plos.github.io/ambraproject/example/themes.tar.gz
 tar -xvzf themes.tar.gz
+```
+
+Edit `/etc/ambra/wombat.yaml` and replace $HOME with the actual path to your home directory:
+```bash
+cd $HOME
+pwd # This prints the path to your home directory. Edit the file /etc/ambra/wombat.yaml and replace $HOME with this path.  
 ```
 
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -18,7 +18,7 @@ These instructions are targeted at Linux and iOS systems. We have not tried to i
 1. [Walkthrough of the Ambra core components](#walkthrough-of-the-ambra-core-components)
     1. [Wombat](#wombat)
     2. [Rhino](#rhino)
-    3. [Content Repo](#content-repo-crepo)
+    3. [Content Repo](#content-repo)
 2. [Obtaining the binaries](#obtaining-the-binaries)
 3. [System setup](#system-setup)
     1. [Requirements](#requirements)
@@ -43,7 +43,7 @@ Wombat is the front-end component of the publishing platform. Wombat is a web ap
 
 Rhino is the back-end service for ingesting and storing article content and metadata. Rhino provides an API to create, read, update, and delete articles and associated data.
 
-## Content Repo (CRepo)
+## Content Repo
 
 The Content Repo is an append-only repository of article assets, including the manuscript XML and all images.
 
@@ -78,13 +78,13 @@ Maven is required to compile components of the Ambra stack. Each component can b
 Your runtime environment must support Java 8 or later. To develop and compile the webapps, the Java 8 Development Kit (JDK8) is required.
 
 ### Tomcat
-Ambra has been tested with Tomcat 7.
+Ambra has been tested with Tomcat 7 and should be compatible with the latest Tomcat.
 
-## Setting Up the Databases
 
 ### MySQL
-Ambra requires a running MySQL server. Ambra should be compatible with the latest version of MySQL. Tested with 5.6.28.
+Ambra requires a running MySQL server. It has been tested with version 5.6.28 and should be compatible with the latest version of MySQL.
 
+## Setting Up the Databases
 #### Ambra database
 
 ```bash
@@ -92,21 +92,21 @@ mysql -uroot -e "DROP DATABASE IF EXISTS ambra;"
 mysql -uroot -e "CREATE DATABASE ambra;"
 ```
 
-Download the Ambra schema ([`ambra-schema.sql`](https://plos.github.io/ambraproject/example/ambra-schema.sql)) and import it into the `ambra` database. For example:
+Download the Ambra schema ([`ambra-schema.sql`](https://plos.github.io/ambraproject/example/ambra-schema.sql)) and import it into the `ambra` database:
 
 ```bash
 mysql -h 127.0.0.1 -P 3306 -uroot -p ambra < ambra-schema.sql
 ```
 
-Add a journal to the database. For example:
+Add a journal to the database:
 
 ```sql
 INSERT INTO journal (`journalKey`, `title`, `eissn`) VALUES ("my_journal", "My Journal", "0000-0000");
 ```
 
-* The field `journalKey` is an identifier used in config files. It must match the key configured in `journal.yaml` ([see below](#themes-configuration)).
-* The field `title` is the reader-facing display form of the title.
-* The field `eissn` is the journal's [electronic ISSN (e-ISSN)](http://www.issn.org/). It must match the e-ISSN for articles ingested into the system (see the [Ingestible Package Guide](https://plos.github.io/ambraproject/Ingestible-Package-Guide.html) for details). On a toy system, use a dummy value such as `0000-0000`.
+* `journalKey` - an identifier used in config files. It must match the key configured in `journal.yaml` ([see below](#themes-configuration)).
+* `title` - the reader-facing display form of the title.
+* `eissn` - the journal's [electronic ISSN (e-ISSN)](http://www.issn.org/). It must match the e-ISSN for articles ingested into the system (see the [Ingestible Package Guide](https://plos.github.io/ambraproject/Ingestible-Package-Guide.html) for details). On a toy system, use a dummy value such as `0000-0000`.
 
 #### Content Repo database
 
@@ -115,7 +115,7 @@ mysql -uroot -e "DROP DATABASE IF EXISTS repo;"
 mysql -uroot -e "CREATE DATABASE repo;"
 ```
 
-Download the Content Repo schema ([`content-repo-schema.sql`](https://plos.github.io/ambraproject/example/content-repo-schema.sql)) and import it into the `repo` database. For example:
+Download the Content Repo schema ([`content-repo-schema.sql`](https://plos.github.io/ambraproject/example/content-repo-schema.sql)) and import it into the `repo` database:
 
 ```bash
 mysql -h 127.0.0.1 -P 3306 -uroot -p repo < content-repo-schema.sql
@@ -129,13 +129,13 @@ INSERT INTO buckets (`bucketName`) VALUES ("corpus");
 
 ### Directories
 
-You will need to create a configuration directory and a directory to hold files in CRepo's datastore.
+You will need to create a configuration directory and a directory to hold files in Content Repo's datastore.
 
 On a toy system, a recommended setup is:
 
 ```bash
   mkdir $HOME/ambra
-  mkdir $HOME/ambra/crepo_datastore  # CRepo datastore directory
+  mkdir $HOME/ambra/crepo_datastore  # Content Repo datastore directory
   mkdir $HOME/ambra/config           # configuration directory
 ```
 
@@ -154,13 +154,12 @@ The files listed above have some required fields - see the example files include
 
 #### Wombat
 
-Wombat requires a configuration file named `wombat.yaml` placed in the configuration directory.
-`wombat.yaml` has some required fields - see the [example](https://plos.github.io/ambraproject/example/wombat.yaml) file.
+Wombat requires a configuration file named `wombat.yaml` ([example](https://plos.github.io/ambraproject/example/wombat.yaml)) placed in the configuration directory. It has some required fields.
 The `path` variable must have an actual path, don't use $HOME.
 
 #### Content Repo
 
-In addition to the Rhino configuration, the `context.xml` in your configuration directory must also be configured to provide Content Repo with a directory to use as its data store. See the [example](https://plos.github.io/ambraproject/example/context.xml) file.
+In addition to the Rhino configuration, the `context.xml` ([example](https://plos.github.io/ambraproject/example/context.xml)) in your configuration directory must also be configured to provide Content Repo with a directory to use as its data store.
 
 ## Setting up a theme directory
 
@@ -207,7 +206,7 @@ This overrides the file found in Wombat's source code at
 src/main/webapp/WEB-INF/themes/root/config/journal.yaml
 ```
 
-There are two required fields: `journalKey` and `journalName`. [See an example.](https://plos.github.io/ambraproject/example/journal.yaml)
+There are two required fields: `journalKey` and `journalName`. ([example](https://plos.github.io/ambraproject/example/journal.yaml))
 
 Other config files control the application's behavior in other ways; `journal.yaml` is the only mandatory override. They are documented by the root files in Wombat's source code, which you may override individually.
 
@@ -235,7 +234,7 @@ You may also run each component from Maven. This is where you will set the appli
 
 1. Wombat: `mvn tomcat6:run -Dmaven.tomcat.port=8080 -Dwombat.configDir=/etc/ambra`
 2. Rhino: `mvn tomcat6:run -Dmaven.tomcat.port=8082 -Drhino.configDir=/etc/ambra`
-3. Crepo: `mvn tomcat6:run -Dmaven.tomcat.port=8081`
+3. Content Repo: `mvn tomcat6:run -Dmaven.tomcat.port=8081`
 
 Note: Run these mvn commands from the directory you cloned each project.
 
@@ -244,7 +243,7 @@ Note: Run these mvn commands from the directory you cloned each project.
 Go to `http://localhost:<PORT>` to view the root page for each application.
 
 1. Rhino: Swagger API interface
-2. CRepo: Swagger API interface
+2. Content Repo: Swagger API interface
 3. Wombat: Debug or root page
 
 ## Ingesting an article

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -163,9 +163,7 @@ Wombat requires it's own configuration file placed in the configuration director
 It has some required fields.
 The `path` variable must have an actual path, don't use $HOME.
 
-## Setting up a theme directory
-
-Create a new directory to house your site's theme configuration. The easiest way to create this directory is to explode the starter [`themes.tar.gz`](https://plos.github.io/ambraproject/example/themes.tar.gz) archive. For example, if you are using a `$HOME/ambra` directory as in the example above, then do
+Wombat can be themed and will not start without having a theme installed.  Create the theme by downloading and extracting the following archive [`themes.tar.gz`](https://plos.github.io/ambraproject/example/themes.tar.gz).
 
 ```bash
 cd $HOME/ambra/
@@ -173,60 +171,6 @@ wget https://plos.github.io/ambraproject/example/themes.tar.gz
 tar -xvzf themes.tar.gz
 ```
 
-This will create a directory named `$HOME/ambra/themes`. It will contain:
-
-* a file named `sites.yaml`, which describes the publication sites to be hosted by your server (just one to start); and
-* a directory named `main/`, which is the theme for your one site.
-
-There is no significance to the directory name `main/`, you may change it to anything you wish. You may also change the initial site key in `sites.yaml` to a string that identifies your site.
-
-On a production system, `/var/themes` is recommended instead of `$HOME/ambra/themes`.
-
-### Theme Overrides
-
-Every Freemarker Template, configuration, and resource file in Wombat can be overridden in your theme. This allows you to customize your site.
-
-Wombat's built-in themes are located in its source code at
-
-* `src/main/webapp/WEB-INF/themes/root`
-* `src/main/webapp/WEB-INF/themes/desktop`
-* `src/main/webapp/WEB-INF/themes/mobile`
-
-You may [explore these directories](https://github.com/PLOS/wombat/tree/master/src/main/webapp/WEB-INF/themes) to find templates and configuration files that you can override. Two examples follow.
-
-#### Journal Configuration
-
-A theme requires a file named `journal.yaml` placed in the `config` directory at the theme path. For example:
-
-```
-$HOME/ambra/themes/main/config/journal.yaml
-```
-
-This overrides the file found in Wombat's source code at
-
-```
-src/main/webapp/WEB-INF/themes/root/config/journal.yaml
-```
-
-There are two required fields: `journalKey` and `journalName`. ([example](https://plos.github.io/ambraproject/example/journal.yaml))
-
-Other config files control the application's behavior in other ways; `journal.yaml` is the only mandatory override. They are documented by the root files in Wombat's source code, which you may override individually.
-
-#### Homepage Customization
-
-You can get started by setting your homepage content with a theme override. The homepage body is defined by the theme file at `ftl/home/body.ftl`. Create a file at this path in your theme; for example:
-
-```
-$HOME/ambra/themes/main/ftl/home/body.ftl
-```
-
-Edit it to fill in the HTML or FreeMarker code for your homepage content.
-
-To define new resources to use in your homepage, such as images or CSS files, place the files at the `resource` theme path (e.g., `$HOME/ambra/themes/main/resource/`). Any files placed here can be linked at the `resource/` path, relative to your homepage URL. For example, you could create an image named `$HOME/ambra/themes/main/resource/banner.jpg` and then link to it from your homepage with
-
-```html
-<img src="resource/banner.jpg" />
-```
 
 ## Deploying the artifacts to Tomcat
 

--- a/Quickstart-Guide.md
+++ b/Quickstart-Guide.md
@@ -19,7 +19,7 @@ These instructions are targeted at Linux and iOS systems. We have not tried to i
     1. [Wombat](#wombat)
     2. [Rhino](#rhino)
     3. [Content Repo](#content-repo)
-2. [Obtaining the binaries](#obtaining-the-binaries)
+2. [Obtaining the Applications](#obtaining-the-applications)
 3. [System setup](#system-setup)
     1. [Requirements](#requirements)
     2. [Setting up the databases](#setting-up-the-databases)
@@ -47,21 +47,23 @@ Rhino is the back-end service for ingesting and storing article content and meta
 
 The Content Repo is an append-only repository of article assets, including the manuscript XML and all images.
 
-# Quickstart using Docker
+# Obtaining the Applications
+## Download the latest releases
 
-You can quickly bring up an auto configured Ambra stack using Docker instead of having to install Java and download all the binaries. [See our Docker setup guide](https://github.com/PLOS/Dockerfiles/wiki/Ambra-Quick-Start).
+You can run Ambra in Tomcat without compiling any code.  Download latest releases:
+- [Wombat](https://plos.github.io/ambraproject/Releases.html#wombat)
+- [Rhino](https://plos.github.io/ambraproject/Releases.html#rhino)
+- [Content Repo](https://plos.github.io/ambraproject/Releases.html#content-repo)
 
-# Obtaining the binaries
-
-If you have Tomcat installed on your system, you can set up and run Ambra without compiling any code. Download `.war` files from our [Releases page](https://plos.github.io/ambraproject/Releases.html), and follow the instructions for [deploying the artifacts to Tomcat](#deploying-the-artifacts-to-tomcat).
-
-You can also check out the source code and compile the `.war` artifacts for youself. The source code repositories are located at:
+## Alternative: Run the source code
+You can check out the source code and compile the `.war` files. Follow the quick start guide and run the applications with Maven instead of deploying the web app to Tomcat.  The source repositories are here:
 
 * [Wombat](https://github.com/PLOS/wombat.git)
 * [Rhino](https://github.com/PLOS/rhino.git)
 * [Content Repo](https://github.com/PLOS/content-repo.git)
 
-Maven is required to compile components of the Ambra stack. Each component can be compiled by executing `mvn install` from the checked-out directory.
+## Alternative: Docker
+[See our Docker setup guide](https://github.com/PLOS/Dockerfiles/wiki/Ambra-Quick-Start).  You can quickly bring up an auto-configured Ambra stack using Docker instead of having to follow this quickstart guide.
 
 # System setup
 
@@ -72,7 +74,6 @@ Maven is required to compile components of the Ambra stack. Each component can b
 2. Tomcat
 3. MySQL
 4. Solr (optional)
-5. Maven (optional)
 
 ### Java 8
 Your runtime environment must support Java 8 or later. To develop and compile the webapps, the Java 8 Development Kit (JDK8) is required.
@@ -170,25 +171,25 @@ tar -xvzf themes.tar.gz
 ```
 
 
-## Deploying the applications to Tomcat
+## Running the applications
 
-If you have downloaded or compiled `.war` files, you may deploy them to a Tomcat instance as normal. (Consult the Tomcat documentation for details.)
+You should be familiar with how to deploy a webapp to Tomcat. Typically, `.war` files are simply copied into Tomcat's `webapps` directory and Tomcat will start the webapp automatically.
 
-You may also run each component from Maven. This is where you will set the application port as well as define the configuration directory:
+### Alternative: Running the application from source code with Maven
+Use Maven to run the applications from source. For each respective app you must be in the checked-out repository directory.
+1. Compile the app: `mvn install`
+2. Run the app:
+   1. Wombat: `mvn tomcat6:run -Dmaven.tomcat.port=8080 -Dwombat.configDir=/etc/ambra`
+   2. Rhino: `mvn tomcat6:run -Dmaven.tomcat.port=8082 -Drhino.configDir=/etc/ambra`
+   3. Content Repo: `mvn tomcat6:run -Dmaven.tomcat.port=8081`
 
-1. Wombat: `mvn tomcat6:run -Dmaven.tomcat.port=8080 -Dwombat.configDir=/etc/ambra`
-2. Rhino: `mvn tomcat6:run -Dmaven.tomcat.port=8082 -Drhino.configDir=/etc/ambra`
-3. Content Repo: `mvn tomcat6:run -Dmaven.tomcat.port=8081`
-
-Note: Run these mvn commands from the directory you cloned each project.
-
-### Viewing the "hello world" page for each component
+## Viewing the "hello world" page for each component
 
 Go to `http://localhost:<PORT>` to view the root page for each application.
 
-1. Rhino: Swagger API interface
-2. Content Repo: Swagger API interface
-3. Wombat: Debug or root page
+1. Wombat: You should see an introductory web page at `http://localhost:8080`
+2. Rhino: You should see a Swagger API interface at `http://localhost:8082`
+3. Content Repo: You should see a Swagger API interface at `http://localhost:8081`
 
 ## Ingesting an article
 

--- a/example/content-repo-schema.sql
+++ b/example/content-repo-schema.sql
@@ -1,0 +1,177 @@
+-- MySQL dump 10.13  Distrib 5.6.38-83.0, for osx10.12 (x86_64)
+--
+-- Host: localhost    Database: repo
+-- ------------------------------------------------------
+-- Server version	5.7.21
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `audit`
+--
+
+DROP TABLE IF EXISTS `audit`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `audit` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `bucketName` varchar(255) NOT NULL,
+  `keyValue` varchar(255) DEFAULT NULL,
+  `operation` varchar(20) NOT NULL,
+  `uuid` char(36) DEFAULT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=6006 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `audit`
+--
+
+LOCK TABLES `audit` WRITE;
+/*!40000 ALTER TABLE `audit` DISABLE KEYS */;
+/*!40000 ALTER TABLE `audit` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `buckets`
+--
+
+DROP TABLE IF EXISTS `buckets`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `buckets` (
+  `bucketId` int(11) NOT NULL AUTO_INCREMENT,
+  `bucketName` varchar(255) NOT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `creationDate` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`bucketId`),
+  UNIQUE KEY `keyBucket` (`bucketName`)
+) ENGINE=InnoDB AUTO_INCREMENT=160 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `buckets`
+--
+
+LOCK TABLES `buckets` WRITE;
+/*!40000 ALTER TABLE `buckets` DISABLE KEYS */;
+/*!40000 ALTER TABLE `buckets` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `collectionObject`
+--
+
+DROP TABLE IF EXISTS `collectionObject`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `collectionObject` (
+  `collectionId` int(11) NOT NULL,
+  `objectId` int(11) NOT NULL,
+  UNIQUE KEY `keySum` (`collectionId`,`objectId`),
+  KEY `objectId` (`objectId`),
+  CONSTRAINT `collectionobject_ibfk_1` FOREIGN KEY (`collectionId`) REFERENCES `collections` (`id`),
+  CONSTRAINT `collectionobject_ibfk_2` FOREIGN KEY (`objectId`) REFERENCES `objects` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `collectionObject`
+--
+
+LOCK TABLES `collectionObject` WRITE;
+/*!40000 ALTER TABLE `collectionObject` DISABLE KEYS */;
+/*!40000 ALTER TABLE `collectionObject` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `collections`
+--
+
+DROP TABLE IF EXISTS `collections`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `collections` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `bucketId` int(11) NOT NULL,
+  `collkey` varchar(255) NOT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `versionNumber` int(11) DEFAULT NULL,
+  `status` tinyint(4) NOT NULL DEFAULT '0',
+  `tag` varchar(200) DEFAULT NULL,
+  `creationDate` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `userMetadata` longtext,
+  `uuid` char(36) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `CollkeyUniversalID` (`bucketId`,`collkey`,`uuid`),
+  UNIQUE KEY `keyVersion` (`bucketId`,`collkey`,`versionNumber`),
+  CONSTRAINT `collections_ibfk_1` FOREIGN KEY (`bucketId`) REFERENCES `buckets` (`bucketId`)
+) ENGINE=InnoDB AUTO_INCREMENT=79 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `collections`
+--
+
+LOCK TABLES `collections` WRITE;
+/*!40000 ALTER TABLE `collections` DISABLE KEYS */;
+/*!40000 ALTER TABLE `collections` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `objects`
+--
+
+DROP TABLE IF EXISTS `objects`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `objects` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `bucketId` int(11) DEFAULT NULL,
+  `objkey` varchar(255) NOT NULL,
+  `checksum` varchar(255) NOT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `downloadName` varchar(1000) DEFAULT NULL,
+  `contentType` varchar(200) DEFAULT NULL,
+  `size` int(11) NOT NULL,
+  `tag` varchar(200) DEFAULT NULL,
+  `status` tinyint(4) NOT NULL DEFAULT '0',
+  `versionNumber` int(11) NOT NULL,
+  `creationDate` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `userMetadata` longtext,
+  `uuid` char(36) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ObjkeyUniversalID` (`bucketId`,`objkey`,`uuid`),
+  UNIQUE KEY `keyVersion` (`bucketId`,`objkey`,`versionNumber`)
+) ENGINE=InnoDB AUTO_INCREMENT=4041 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `objects`
+--
+
+LOCK TABLES `objects` WRITE;
+/*!40000 ALTER TABLE `objects` DISABLE KEYS */;
+/*!40000 ALTER TABLE `objects` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2018-02-12 16:40:36

--- a/example/wombat.yaml
+++ b/example/wombat.yaml
@@ -1,5 +1,5 @@
 
-server: http://localhost:8123/
+server: http://localhost:8082/
 # URL of the server for the service API ("Rhino")
 
 themeSources:

--- a/themes-customizing.md
+++ b/themes-customizing.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: Themes Quickstart
+navigation_weight: 4
+
+---
+
+
+## Setting up a theme directory
+
+Following the Quickstart Guide you will have created a directory at the path `$HOME/ambra/themes`. It contains:
+
+* a file named `sites.yaml`, which describes the publication sites to be hosted by your server (just one to start); and
+* a directory named `main/`, which is the theme for your one site.
+
+There is no significance to the directory name `main/`, you may change it to anything you wish. You may also change the initial site key in `sites.yaml` to a string that identifies your site.
+
+On a production system, `/var/themes` is recommended instead of `$HOME/ambra/themes`.
+
+### Theme Overrides
+
+Every Freemarker Template, configuration, and resource file in Wombat can be overridden in your theme. This allows you to customize your site.
+
+Wombat's built-in themes are located in its source code at
+
+* `src/main/webapp/WEB-INF/themes/root`
+* `src/main/webapp/WEB-INF/themes/desktop`
+* `src/main/webapp/WEB-INF/themes/mobile`
+
+You may [explore these directories](https://github.com/PLOS/wombat/tree/master/src/main/webapp/WEB-INF/themes) to find templates and configuration files that you can override. Two examples follow.
+
+#### Journal Configuration
+
+A theme requires a file named `journal.yaml` placed in the `config` directory at the theme path. For example:
+
+```
+$HOME/ambra/themes/main/config/journal.yaml
+```
+
+This overrides the file found in Wombat's source code at
+
+```
+src/main/webapp/WEB-INF/themes/root/config/journal.yaml
+```
+
+There are two required fields: `journalKey` and `journalName`. ([example](https://plos.github.io/ambraproject/example/journal.yaml))
+
+Other config files control the application's behavior in other ways; `journal.yaml` is the only mandatory override. They are documented by the root files in Wombat's source code, which you may override individually.
+
+#### Homepage Customization
+
+You can get started by setting your homepage content with a theme override. The homepage body is defined by the theme file at `ftl/home/body.ftl`. Create a file at this path in your theme; for example:
+
+```
+$HOME/ambra/themes/main/ftl/home/body.ftl
+```
+
+Edit it to fill in the HTML or FreeMarker code for your homepage content.
+
+To define new resources to use in your homepage, such as images or CSS files, place the files at the `resource` theme path (e.g., `$HOME/ambra/themes/main/resource/`). Any files placed here can be linked at the `resource/` path, relative to your homepage URL. For example, you could create an image named `$HOME/ambra/themes/main/resource/banner.jpg` and then link to it from your homepage with
+
+```html
+<img src="resource/banner.jpg" />
+```

--- a/themes-documentation.md
+++ b/themes-documentation.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Working with PLOS's Themes
-navigation_weight: 4
+navigation_weight: 5
 
 ---
 


### PR DESCRIPTION
The updates the quick start to be more opinionated and sufficient to actually run the ambra stack.
Notes:

- It suggests a quicker path to getting the app running locally.  Alternatives are offered but de-emphasized.
- I emphasized running from source with maven over deploying the .war files to tomcat because I could not get the latter to work.  Probably a personal failure but this ticket is timeboxed so I left in the best state I could.
- Included steps to create the Content Repo DB, which were not present before.
- wombat can be started but it is just an empty page that says: "Congratulations!  You have setup Wombat correctly!"